### PR TITLE
feat: added netstandard1.0 as a target

### DIFF
--- a/src/ComparisonExtensions/ComparisonExtensions.csproj
+++ b/src/ComparisonExtensions/ComparisonExtensions.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>netstandard1.0;net6.0</TargetFrameworks>
+        <LangVersion>9</LangVersion>
         <Title>Floating Comparison Extensions</Title>
         <Authors>kerimbal</Authors>
         <Description>Extension for floating types for comparison with a certain precision value. </Description>
         <PackageTags>.NET, C#,  double, single, compare, comparison</PackageTags>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.0.0.0</FileVersion>
+        <AssemblyVersion>1.1.0.0</AssemblyVersion>
+        <FileVersion>1.1.0.0</FileVersion>
         <PackageId>FloatingComparisonExtensions</PackageId>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/test/ComparisonExtensionsTests/ComparisonExtensionsTests.csproj
+++ b/test/ComparisonExtensionsTests/ComparisonExtensionsTests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-
+        <TargetFrameworks>net48;net5.0;net6.0</TargetFrameworks>
+        <LangVersion>9</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -18,6 +18,13 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="PolySharp" Version="1.13.2">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
adding netstandard1.0 support. set test project to specifically test net48, net5 and net6 to ensure tests pass on these 3 versions. 

PolySharp is added to the test project to give net48 support for records.